### PR TITLE
fix(project): resolve navigation imports and Gradle plugin conflicts

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,20 +1,21 @@
 plugins {
-    id 'com.android.application'
-    id 'org.jetbrains.kotlin.android'
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+    id("org.jetbrains.kotlin.plugin.compose")
 }
 
 android {
-    namespace "com.example.tick"
-    compileSdk 34
+    namespace = "com.example.tick"
+    compileSdk = 36
 
     defaultConfig {
-        applicationId "com.example.tick"
-        minSdk 24
-        targetSdk 34
-        versionCode 1
-        versionName "1.0"
+        applicationId = "com.example.tick"
+        minSdk = 24
+        targetSdk = 36
+        versionCode = 1
+        versionName = "1.0"
 
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {
             useSupportLibrary = true
         }
@@ -22,23 +23,27 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
         }
     }
+
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-                targetCompatibility JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
+
     kotlinOptions {
         jvmTarget = "17"
     }
+
     buildFeatures {
-        compose true
+        compose = true
     }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.3"
-    }
+
     packaging {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
@@ -47,32 +52,39 @@ android {
 }
 
 dependencies {
-    implementation platform("androidx.compose:compose-bom:2024.09.00")
-    implementation "androidx.compose.ui:ui"
-    implementation "androidx.compose.ui:ui-graphics"
-    implementation "androidx.compose.ui:ui-tooling-preview"
-    implementation "androidx.compose.material3:material3"
+    implementation(platform("androidx.compose:compose-bom:2025.09.01"))
+
+    // Material Icons
+    implementation("androidx.compose.material:material-icons-extended")
+
+    // Jetpack Compose
+    implementation("androidx.compose.ui:ui")
+    implementation("androidx.compose.ui:ui-graphics")
+    implementation("androidx.compose.ui:ui-tooling-preview")
+    implementation("androidx.compose.material3:material3")
+    implementation("androidx.compose.runtime:runtime")
 
     // Lifecycle + ViewModel
-    implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.8.6"
-    implementation "androidx.lifecycle:lifecycle-viewmodel-compose:2.8.6"
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.6")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.6")
 
     // Coroutines + Flow
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.9.0"
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.9.0")
 
     // Activity Compose
-    implementation "androidx.activity:activity-compose:1.9.3"
+    implementation("androidx.activity:activity-compose:1.9.3")
 
     // Jetpack Compose Navigation
     implementation("androidx.navigation:navigation-compose:2.8.3")
+    implementation("androidx.navigation:navigation-runtime-ktx:2.8.3")
 
     // Tooling + Test
-    debugImplementation "androidx.compose.ui:ui-tooling"
-    debugImplementation "androidx.compose.ui:ui-test-manifest"
-    testImplementation "junit:junit:4.13.2"
-    androidTestImplementation "androidx.test.ext:junit:1.2.1"
-    androidTestImplementation "androidx.test.espresso:espresso-core:3.6.1"
-    androidTestImplementation platform("androidx.compose:compose-bom:2024.09.00")
-    androidTestImplementation "androidx.compose.ui:ui-test-junit4"
+    debugImplementation("androidx.compose.ui:ui-tooling")
+    debugImplementation("androidx.compose.ui:ui-test-manifest")
+    testImplementation("junit:junit:4.13.2")
+    androidTestImplementation("androidx.test.ext:junit:1.2.1")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
+    androidTestImplementation(platform("androidx.compose:compose-bom:2025.09.01"))
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4")
 }

--- a/app/src/main/java/com/example/tick/MainActivity.kt
+++ b/app/src/main/java/com/example/tick/MainActivity.kt
@@ -7,7 +7,7 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.*
 import androidx.navigation.compose.rememberNavController
-import com.example.tick.ui.navigation.AppNavGraph
+import com.example.tick.uidesign.navigation.AppNavGraph
 import com.example.tick.ui.theme.TickTheme
 
 class MainActivity : ComponentActivity() {

--- a/app/src/main/java/com/example/tick/uidesign/AddTaskScreen.kt
+++ b/app/src/main/java/com/example/tick/uidesign/AddTaskScreen.kt
@@ -1,4 +1,4 @@
-package com.example.tick.ui
+package com.example.tick.uidesign
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*

--- a/app/src/main/java/com/example/tick/uidesign/EditTaskScreen.kt
+++ b/app/src/main/java/com/example/tick/uidesign/EditTaskScreen.kt
@@ -1,4 +1,4 @@
-package com.example.tick.ui
+package com.example.tick.uidesign
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*

--- a/app/src/main/java/com/example/tick/uidesign/MainScreen.kt
+++ b/app/src/main/java/com/example/tick/uidesign/MainScreen.kt
@@ -1,4 +1,4 @@
-package com.example.tick.ui
+package com.example.tick.uidesign
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*

--- a/app/src/main/java/com/example/tick/uidesign/navigation/NavGraph.kt
+++ b/app/src/main/java/com/example/tick/uidesign/navigation/NavGraph.kt
@@ -1,13 +1,13 @@
-package com.example.tick.ui.navigation
+package com.example.tick.uidesign.navigation
 
 import androidx.compose.runtime.Composable
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
-import com.example.tick.ui.MainScreen
-import com.example.tick.ui.AddTaskScreen
-import com.example.tick.ui.EditTaskScreen
+import com.example.tick.uidesign.MainScreen
+import com.example.tick.uidesign.AddTaskScreen
+import com.example.tick.uidesign.EditTaskScreen
 import com.example.tick.viewmodel.TaskViewModel
 
 sealed class Screen(val route: String) {
@@ -29,6 +29,7 @@ fun AppNavGraph(
         navController = navController,
         startDestination = Screen.Main.route
     ) {
+        // Main Screen
         composable(Screen.Main.route) {
             MainScreen(
                 viewModel = taskViewModel,
@@ -40,6 +41,8 @@ fun AppNavGraph(
                 onToggleTheme = onToggleTheme
             )
         }
+
+        // Add Task Screen
         composable(Screen.AddTask.route) {
             AddTaskScreen(
                 viewModel = taskViewModel,
@@ -47,6 +50,8 @@ fun AppNavGraph(
                 onCancel = { navController.popBackStack() }
             )
         }
+
+        // Edit Task Screen
         composable(Screen.EditTask.route) { backStackEntry ->
             val taskId = backStackEntry.arguments?.getString("taskId")?.toIntOrNull()
             if (taskId != null) {


### PR DESCRIPTION
- Corrected imports for MainScreen, AddTaskScreen, and EditTaskScreen (moved to uidesign package)
- Updated NavGraph to use the correct package references
- Fixed app/build.gradle.kts to use Kotlin Compose plugin with proper version
- Adjusted project-level build.gradle.kts to align plugin versions